### PR TITLE
Fixes + improvements

### DIFF
--- a/6. Infinite Grass Rendering/Assets/Shaders/GrassBillboardPass.hlsl
+++ b/6. Infinite Grass Rendering/Assets/Shaders/GrassBillboardPass.hlsl
@@ -20,11 +20,8 @@ struct VertexOutput
     float2 uv : TEXCOORD0;
     float3 normal : NORMAL;
     float3 dynamicWorldPos: TEXCOORD3;//world position moved by wind and other things
-    float3 staticWorldPos: TEXCOORD4;//static world position for sampling a texture
-    float3 scale: TEXCOORD5;
     float distToCam: TEXCOORD6;
     float textureNoise: TEXCOORD7;
-    uint lodIndex : TEXCOORD8;
 };
 
 //individuall buffers per material
@@ -93,7 +90,7 @@ void Applyfog(inout float4 color, float3 positionWS)
 #endif
 }
 
-void ApplyTexColor(float3 worldPos, float2 uv, float textureNoise, out float4 texCol) {
+void ApplyTexColor(float2 uv, float textureNoise, out float4 texCol) {
     uv = uv * agr_billboardTextures_ST.xy + agr_billboardTextures_ST.zw;
     float index = floor(textureNoise * (agr_billboardTextureCount));
     texCol = SAMPLE_TEXTURE2D_ARRAY(agr_billboardTextures, sampler_agr_billboardTextures, uv, index);
@@ -106,7 +103,6 @@ VertexOutput vert (VertexInput input, uint instanceID : SV_InstanceID)
 
     uint index = instanceData.trsIndex; 
     uint lodIndex = instanceData.lodIndex;
-    output.lodIndex = lodIndex;
 
 #ifdef SHADOW_CASTER_PASS
     if (lodIndex > 0)
@@ -127,7 +123,6 @@ VertexOutput vert (VertexInput input, uint instanceID : SV_InstanceID)
 
     //applying transformation matrix
     float3 staticWorldPos = mul(mat, float4(vertex.xyz, 1));
-    output.staticWorldPos = staticWorldPos;
 
     float3 camPos = _WorldSpaceCameraPos;
     output.distToCam = distance(staticWorldPos, camPos);
@@ -144,7 +139,6 @@ VertexOutput vert (VertexInput input, uint instanceID : SV_InstanceID)
         noise = (noise - .5) * 2.; 
         scale = GetScaleFromMatrix(mat);
     }
-    output.scale = scale;
 
 
     //to keep bottom part of mesh at its position
@@ -159,12 +153,12 @@ VertexOutput vert (VertexInput input, uint instanceID : SV_InstanceID)
     //distortion based on view
     float3 viewDisplacement = mul(UNITY_MATRIX_VP, input.normal) * dynamicWorldPos.z;
     dynamicWorldPos.xz += ((1. - viewDisplacement) * 0.0001) * output.uv.y;
-    output.dynamicWorldPos = dynamicWorldPos;
+    output.dynamicWorldPos = dynamicWorldPos; 
 
     output.vertex = mul(UNITY_MATRIX_VP, float4(dynamicWorldPos, 1));
 
     //generating texture noise in vertex stage to improve performance
-    output.textureNoise = GetGrassNoise(output.staticWorldPos);
+    output.textureNoise = GetGrassNoise(staticWorldPos);
 
     output.normal = (agr_flatShading < 0) ? input.normal : 0;
     return output;
@@ -179,7 +173,7 @@ float4 frag (VertexOutput input) : SV_Target
     float4 texCol = 0;
     float noise = input.textureNoise;
 
-    ApplyTexColor(input.staticWorldPos, input.uv, noise, texCol);
+    ApplyTexColor(input.uv, noise, texCol);
 
     texCol.a *= (1. - fade);
     if (texCol.a < agr_alphaCutoff) {

--- a/6. Infinite Grass Rendering/Assets/Shaders/GrassRenderer.compute
+++ b/6. Infinite Grass Rendering/Assets/Shaders/GrassRenderer.compute
@@ -241,7 +241,7 @@ void InitInstanceTransforms(uint3 id : SV_DispatchThreadID)
     float3 instancePos;
     float2 uv;
 
-    for (uint i = 0; i < count; i++)
+    for (uint i = 0; i < instancesPerChunk; i++)
     {
         GenerateChunkData(i, chunkPos, instancePos, instanceSeed, uv, gradientNoise);
         //This condition has to match the one in InitChunkInstanceCount() in order to skip the exact same invalid instances.

--- a/6. Infinite Grass Rendering/Assets/Shaders/GrassRenderer.compute
+++ b/6. Infinite Grass Rendering/Assets/Shaders/GrassRenderer.compute
@@ -182,7 +182,12 @@ float3 GenerateInstancePos(float3 chunkPos, uint instanceSeed) {
 }
 
 void GenerateChunkData(uint i, float3 chunkPos, out float3 instancePos, out uint instanceSeed, out float2 terrainUV, out float gradientNoise) {
-    instanceSeed = SimpleHash(i + chunkPos.x + chunkPos.z) ;
+    uint cx = asuint(chunkPos.x); //example 8.0f to 0x41000000
+    uint cz = asuint(chunkPos.z);
+    
+    uint chunkHash = SimpleHash(cx * 2246822519u ^ cz * 3266489917u);
+    instanceSeed = SimpleHash(chunkHash ^ (i * 2654435761u));
+
     instancePos = GenerateInstancePos(chunkPos, instanceSeed);
     terrainUV = WorldToTerrainUV(instancePos);  
     Unity_GradientNoise_Deterministic_float(terrainUV, scaleNoiseScale, gradientNoise);


### PR DESCRIPTION
- removed unused interpolants and with that unnecessary operations
- fix grass placement for smaller chunks via better seeding
  - patters now don't become obvious even with very small chunk sizes
-  fix InitInstanceTransforms iteration count: This kernel was using chunk.instanceCount from kernel InitChunkInstanceCount which ran first. But this lead to possible gaps in buffe