### PR TITLE
fix depth texture fetched in scene view not optional

### DIFF
--- a/6. Infinite Grass Rendering/Assets/Scripts/GrassInstancerController.cs
+++ b/6. Infinite Grass Rendering/Assets/Scripts/GrassInstancerController.cs
@@ -14,6 +14,8 @@ namespace Acetix.Grass
         [SerializeField]
         [Tooltip("Will show you the sub chunks.")]
         private bool _drawSubChunks;
+        [Tooltip("(Debug only) Fetches depth texture in scene view so it can also render the instances.")]
+        [SerializeField] private bool _fetchDepthInScene = true;
         [Header("Settings")]
         [SerializeField] public GrassInstancerSettings _settings;
 
@@ -49,6 +51,10 @@ namespace Acetix.Grass
         /// </summary>
         void OnRenderObject()
         {
+            if (!_fetchDepthInScene && Camera.current != null && Camera.current.cameraType == CameraType.SceneView)
+            {
+                return;
+            }
             _cameraDepthTexture = Shader.GetGlobalTexture("_CameraDepthTexture");
             //Depth tex not correctly initialized yet. 
             if (_cameraDepthTexture.width == 4 && _cameraDepthTexture.height == 4)

--- a/6. Infinite Grass Rendering/readme.md
+++ b/6. Infinite Grass Rendering/readme.md
@@ -45,7 +45,7 @@ This can happen if the instancer is not positioned correctly. It should be place
 
 This can happend if the `depth bias` value is not fine tuned. You can play around with it in play mode to find a suiting value.
 
-Another issue could be the `camera depth texture` if you have both scene and game view open or switch between these two during testing. Somehow the creation of this texture can be messed up.
+Another issue could be the `camera depth texture` if you have both scene and game view open or switch between these two during testing (see property `_fetchDepthInScene`);
 
 ### [More issues can be found here.](https://github.com/MangoButtermilch/Unity-Grass-Instancer/blob/main/README.md#faq)
 


### PR DESCRIPTION
targets https://github.com/MangoButtermilch/Unity-Grass-Instancer/issues/11 and addresses https://github.com/MangoButtermilch/Unity-Grass-Instancer/tree/main/6.%20Infinite%20Grass%20Rendering#small-chunks-appear-to-flicker-depending-on-view-angle